### PR TITLE
added webpack config flag to activate historyApiFallback

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,9 @@ module.exports = {
   },
   debug: true,
   devtool: 'source-map',
+  devServer: {
+    historyApiFallback: true
+  },
   module: {
     preLoaders: [{
       test: /\.js$/,


### PR DESCRIPTION
This allows us to have hot reloading via `/webpack-dev-server` while we work. 

As you can see here, the URL structure doesn't change as we go, but HMR may take place.

![sbuilder-hot](https://cloud.githubusercontent.com/assets/8388/13114922/a8e984a0-d563-11e5-91a0-2373731804fd.gif)

> what this does _not_ do: allow us to cut & paste urls beyond '/'
