### PR TITLE
4 webpackdevserver

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,6 @@
   <div id="root"></div>
   <!-- It is important that you point to the full url -->
   <script src="http://localhost:8080/webpack-dev-server.js"></script>
-  <script src="bundle.js"></script>
+  <script src="/bundle.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "./node_modules/webpack-dev-server/bin/webpack-dev-server.js --progress --hot --inline",
+    "start": "./node_modules/webpack-dev-server/bin/webpack-dev-server.js --progress --hot --inline --history-api-fallback --output-public-path /",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "PK2 & WG",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,9 @@ module.exports = {
   },
   debug: true,
   devtool: 'source-map',
+  devServer: {
+    historyApiFallback: true
+  },
   module: {
     preLoaders: [{
       test: /\.js$/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,19 +14,19 @@ module.exports = {
   },
   debug: true,
   devtool: 'source-map',
-  devServer: {
-    historyApiFallback: true
-  },
   module: {
     preLoaders: [{
       test: /\.js$/,
       include: path.join(__dirname, 'src'),
       loader: 'eslint-loader'
     }],
-    loaders: [
-      { test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/, loader: "url-loader?limit=10000&minetype=application/font-woff" },
-      { test: /\.(ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/, loader: "file-loader" },
-      {
+    loaders: [{
+      test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+      loader: "url-loader?limit=10000&minetype=application/font-woff"
+    }, {
+      test: /\.(ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+      loader: "file-loader"
+    }, {
       test: /\.js$/,
       include: path.join(__dirname, 'src'),
       loader: 'babel',


### PR DESCRIPTION
Watch the URL as I cut & paste `/s/[sessionId]`:

![sbuilder-url](https://cloud.githubusercontent.com/assets/8388/13115214/e6339322-d564-11e5-84f4-354795e63214.gif)

In the last PR I failed to set the public URL, which is now being set in the entry point `npm start`. See commit logs for deets.

closes #9 
